### PR TITLE
New sampling method for SVG output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,8 @@ link_directories(${PROJECT_SOURCE_DIR}/lib)
 link_directories(${X11_LIBRARIES})
 
 # add sources and headers
-file(GLOB sources ${PROJECT_SOURCE_DIR}/src/*.cpp ${PROJECT_SOURCE_DIR}/src/images/*.cpp ${PROJECT_SOURCE_DIR}/src/triangles/*.cpp ${PROJECT_SOURCE_DIR}/src/images/*.cpp ${PROJECT_SOURCE_DIR}/src/errorfn/*.cpp)
-file(GLOB headers ${PROJECT_SOURCE_DIR}/include/*.h ${PROJECT_SOURCE_DIR}/include/images/*.h ${PROJECT_SOURCE_DIR}/include/triangles/*.h ${PROJECT_SOURCE_DIR}/src/images/*.h ${PROJECT_SOURCE_DIR}/src/errorfn/*.h)
+file(GLOB sources ${PROJECT_SOURCE_DIR}/src/*.cpp ${PROJECT_SOURCE_DIR}/src/images/*.cpp ${PROJECT_SOURCE_DIR}/src/triangles/*.cpp ${PROJECT_SOURCE_DIR}/src/images/*.cpp ${PROJECT_SOURCE_DIR}/src/errorfn/*.cpp ${PROJECT_SOURCE_DIR}/src/texturesampler/*.cpp)
+file(GLOB headers ${PROJECT_SOURCE_DIR}/include/*.h ${PROJECT_SOURCE_DIR}/include/images/*.h ${PROJECT_SOURCE_DIR}/include/triangles/*.h ${PROJECT_SOURCE_DIR}/src/images/*.h ${PROJECT_SOURCE_DIR}/src/errorfn/*.h ${PROJECT_SOURCE_DIR}/src/texturesampler/*.h)
 
 # copy shaders to build dir
 message(STATUS "Copying shaders to build dir")

--- a/drawer.cpp
+++ b/drawer.cpp
@@ -256,7 +256,8 @@ int Main::run() {
   if (set_svg_file) {
     if (!FINISH_NOW) {
       std::cerr << "Saving SVG..." << std::endl;
-      write_svg(Triangles, Image(IMAGE_FILE), SVG_FILE.c_str());
+      // write_svg(Triangles, Image(IMAGE_FILE), SVG_FILE.c_str());
+      write_svg(Triangles, target, SVG_FILE.c_str());
     } else {
       std::cerr << "Cannot save SVG; program interrupted" << std::endl;
     }

--- a/include/consts.h
+++ b/include/consts.h
@@ -5,6 +5,7 @@ constexpr unsigned int targetImageUnitNumber = 0;
 constexpr unsigned int canvasImageUnitNumber = 1;
 constexpr unsigned int differenceImageUnitNumber = 2;
 constexpr unsigned int cacheImageUnitNumber = 3;
+constexpr unsigned int samplerImageUnitNumber = 4;
 
 constexpr float triCollectionMinZ = (-0.95);
 constexpr float triCollectionMaxZ = 0.95;

--- a/include/images/svg.h
+++ b/include/images/svg.h
@@ -7,8 +7,8 @@
 #include "textureClass.h"
 
 void write_svg(const TriangleCollection &, const Image &,
-               const char *filename);
+               const char *filename, const bool AA=false);
 void write_svg(const TriangleCollection &, Texture &,
-               const char *filename);
+               const char *filename, const bool AA=false);
 
 #endif

--- a/include/images/svg.h
+++ b/include/images/svg.h
@@ -4,8 +4,11 @@
 
 #include "images/image.h"
 #include "triangles/collection.h"
+#include "textureClass.h"
 
 void write_svg(const TriangleCollection &, const Image &,
-               const char *path);
+               const char *filename);
+void write_svg(const TriangleCollection &, Texture &,
+               const char *filename);
 
 #endif

--- a/include/texturesampler/sampler.h
+++ b/include/texturesampler/sampler.h
@@ -1,0 +1,32 @@
+// -*- C++ -*-
+#ifndef TEXTURE_SAMPLER_H
+#define TEXTURE_SAMPLER_H 1
+
+#include "textureClass.h"
+#include "framebuffer.h"
+#include "shaderClass.h"
+
+class TextureSampler {
+public:
+  TextureSampler(Texture &target);
+  ~TextureSampler();
+
+  void SampleTexture(float x, float y, GLfloat &r, GLfloat &g, GLfloat &b);
+
+  GLuint GetSamplerTexID() const { return fSampleBuffer.GetTex(); }
+
+private:
+  void DrawQuad();
+  void RunSampleShader(float, float);
+  void GetBufferColour(GLfloat &r, GLfloat &g, GLfloat &b);
+  
+  Texture &fTarget;
+
+  GLuint VAO;
+  GLuint VBO;
+
+  FramebufferTexture fSampleBuffer;
+  Shader fSampleShader;
+};
+
+#endif

--- a/shaders/sample_shader.glsl
+++ b/shaders/sample_shader.glsl
@@ -1,0 +1,11 @@
+#version 330 core
+layout(location = 0) out vec4 TexColor;
+
+uniform sampler2D target_image;
+uniform vec2 image_size;
+uniform vec2 sample_coord;
+
+void main() {
+     vec3 imageColor = texture(target_image, sample_coord).xyz;
+     TexColor = vec4(imageColor, 1.0);
+}

--- a/shaders/sample_shader.glsl
+++ b/shaders/sample_shader.glsl
@@ -6,6 +6,7 @@ uniform vec2 image_size;
 uniform vec2 sample_coord;
 
 void main() {
-     vec3 imageColor = texture(target_image, sample_coord).xyz;
+     vec2 uv = (sample_coord + 1.)/2.;
+     vec3 imageColor = texture(target_image, uv).xyz;
      TexColor = vec4(imageColor, 1.0);
 }

--- a/src/images/svg.cpp
+++ b/src/images/svg.cpp
@@ -89,11 +89,13 @@ void write_polygon(std::ofstream &outfile, const float verts[6],
   outfile << "fill=\"rgb(" << (int)r << "," << (int)g << "," << (int)b << ")\"/>";
 }
 
-void write_svg_header(std::ofstream &outfile, const int w, const int h) {
+void write_svg_header(std::ofstream &outfile, const int w, const int h, const bool AA=false) {
   // write the header
   // defined viewbox matches OpenGL coordinates, except with y-axis inverted
   outfile << SVG_header;
-  outfile << "width=\"" << w << "\" height=\"" << h << "\" viewBox=\"-1 -1 2 2\"" << SVG_header_end;
+  outfile << "width=\"" << w << "\" height=\"" << h << "\" viewBox=\"-1 -1 2 2\"";
+  if (!AA) outfile << " shape-rendering=\"crispEdges\"";
+  outfile << SVG_header_end;
 
   // add a rect representing the background
   outfile << "<rect x=\"-1\" y=\"-1\" width=\"2\" height=\"2\" stroke=\"none\" fill=\"black\"/>";
@@ -106,10 +108,10 @@ void write_svg_footer(std::ofstream &outfile) {
 // write_svg: write an SVG based on a triangle collection and a
 // reference image
 void write_svg(const TriangleCollection &triangles, const Image &im,
-               const char *filename) {
+               const char *filename, const bool AA) {
   std::ofstream outfile(filename);
 
-  write_svg_header(outfile, im.GetWidth(), im.GetHeight());
+  write_svg_header(outfile, im.GetWidth(), im.GetHeight(), AA);
 
   // add all the triangles in the collection
   for (int i = 0; i < triangles.GetNumTriangles(); ++i) {
@@ -140,10 +142,10 @@ void write_svg(const TriangleCollection &triangles, const Image &im,
 
 // write_svg based on a triangle collection and a loaded texture
 void write_svg(const TriangleCollection &triangles, Texture &tex,
-               const char *filename) {
+               const char *filename, const bool AA) {
   std::ofstream outfile(filename);
 
-  write_svg_header(outfile, tex.GetWidth(), tex.GetHeight());
+  write_svg_header(outfile, tex.GetWidth(), tex.GetHeight(), AA);
 
   // setup the texture sampler
   TextureSampler sampler(tex);

--- a/src/images/svg.cpp
+++ b/src/images/svg.cpp
@@ -83,19 +83,27 @@ void write_polygon(std::ofstream &outfile, const float verts[6],
   outfile << "fill=\"rgb(" << (int)r << "," << (int)g << "," << (int)b << ")\"/>";
 }
 
+void write_svg_header(std::ofstream &outfile, const int w, const int h) {
+  // write the header
+  // defined viewbox matches OpenGL coordinates, except with y-axis inverted
+  outfile << SVG_header;
+  outfile << "width=\"" << w << "\" height=\"" << h << "\" viewBox=\"-1 -1 2 2\"" << SVG_header_end;
+
+  // add a rect representing the background
+  outfile << "<rect x=\"-1\" y=\"-1\" width=\"2\" height=\"2\" stroke=\"none\" fill=\"black\"/>";
+}
+
+void write_svg_footer(std::ofstream &outfile) {
+  outfile << SVG_footer;
+}
+
 // write_svg: write an SVG based on a triangle collection and a
 // reference image
 void write_svg(const TriangleCollection &triangles, const Image &im,
                const char *filename) {
   std::ofstream outfile(filename);
 
-  // write the header
-  // defined viewbox matches OpenGL coordinates, except with y-axis inverted
-  outfile << SVG_header;
-  outfile << "width=\"" << im.GetWidth() << "\" height=\"" << im.GetHeight() << "\" viewBox=\"-1 -1 2 2\"" << SVG_header_end;
-
-  // add a rect representing the background
-  outfile << "<rect x=\"-1\" y=\"-1\" width=\"2\" height=\"2\" stroke=\"none\" fill=\"black\"/>";
+  write_svg_header(outfile, im.GetWidth(), im.GetHeight());
 
   // add all the triangles in the collection
   for (int i = 0; i < triangles.GetNumTriangles(); ++i) {
@@ -119,8 +127,7 @@ void write_svg(const TriangleCollection &triangles, const Image &im,
     write_polygon(outfile, v, r, g, b);
   }
 
-  // write the footer
-  outfile << SVG_footer;
+  write_svg_footer(outfile);
 
   outfile.close();
 }

--- a/src/images/svg.cpp
+++ b/src/images/svg.cpp
@@ -69,6 +69,20 @@ void sample_texture(const Image &im, const float target_x, const float target_y,
   im.GetPixelValue(x, y, r, g, b);
 }
 
+void write_polygon(std::ofstream &outfile, const float verts[6],
+                   const unsigned char r, const unsigned char g,
+                   const unsigned char b) {
+  outfile << "<polygon points=\"";
+
+  // large buffer
+  char buffer[256];
+  std::snprintf(buffer, 255, "%.6f,%.6f %.6f,%.6f %.6f,%.6f", verts[0], -verts[1], verts[2], -verts[3], verts[4], -verts[5]);
+  outfile << buffer;
+
+  outfile << "\" stroke=\"none\" ";
+  outfile << "fill=\"rgb(" << (int)r << "," << (int)g << "," << (int)b << ")\"/>";
+}
+
 // write_svg: write an SVG based on a triangle collection and a
 // reference image
 void write_svg(const TriangleCollection &triangles, const Image &im,
@@ -102,15 +116,7 @@ void write_svg(const TriangleCollection &triangles, const Image &im,
     tri.GetVertices2D(v);
 
     // write the triangle
-    outfile << "<polygon points=\"";
-
-    // large buffer
-    char buffer[256];
-    std::snprintf(buffer, 255, "%.6f,%.6f %.6f,%.6f %.6f,%.6f", v[0], -v[1], v[2], -v[3], v[4], -v[5]);
-    outfile << buffer;
-    
-    outfile << "\" stroke=\"none\" ";
-    outfile << "fill=\"rgb(" << (int)r << "," << (int)g << "," << (int)b << ")\"/>";
+    write_polygon(outfile, v, r, g, b);
   }
 
   // write the footer

--- a/src/texturesampler/sampler.cpp
+++ b/src/texturesampler/sampler.cpp
@@ -12,8 +12,13 @@ const float quadVerts[] = {
   1.0, 1.0 // top right
 };
 
-// TODO:
-TextureSampler::~TextureSampler() {}
+TextureSampler::~TextureSampler() {
+  // delete VAO and VBO
+  glDeleteVertexArrays(1, &VAO);
+  glDeleteBuffers(1, &VBO);
+
+  // other objects should go out of scope
+}
 
 TextureSampler::TextureSampler(Texture &target) : fTarget(target), fSampleBuffer(1, 1, GL_RGB), fSampleShader("shaders/simpleVertShader.glsl", "shaders/sample_shader.glsl") {
   // create VBO and VAO

--- a/src/texturesampler/sampler.cpp
+++ b/src/texturesampler/sampler.cpp
@@ -1,0 +1,72 @@
+#include "texturesampler/sampler.h"
+#include "consts.h"
+
+// quad that fills the screen
+const float quadVerts[] = {
+  -1.0, 1.0, // top left
+  1.0, 1.0, // top right
+  -1.0, -1.0, // bottom left
+
+  -1.0, -1.0, // bottom left
+  1.0, -1.0, // bottom right
+  1.0, 1.0 // top right
+};
+
+// TODO:
+TextureSampler::~TextureSampler() {}
+
+TextureSampler::TextureSampler(Texture &target) : fTarget(target), fSampleBuffer(1, 1, GL_RGB), fSampleShader("shaders/simpleVertShader.glsl", "shaders/sample_shader.glsl") {
+  // create VBO and VAO
+  glGenBuffers(1, &VBO);
+  glGenVertexArrays(1, &VAO);
+  glBindVertexArray(VAO);
+  glBindBuffer(GL_ARRAY_BUFFER, VBO);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(quadVerts), &quadVerts[0], GL_STATIC_DRAW);
+  glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 2*sizeof(float), (void*)0);
+  glEnableVertexAttribArray(0);
+  glBindVertexArray(0);
+
+  // single pixel framebuffer for sampling already created
+  // texture filtering is disabled in framebuffer.cpp, which is essential
+}
+
+void TextureSampler::DrawQuad() {
+  glBindVertexArray(VAO);
+  glBindBuffer(GL_ARRAY_BUFFER, VBO);
+  glDrawArrays(GL_TRIANGLES, 0, 3*2);
+}
+
+void TextureSampler::SampleTexture(float x, float y, GLfloat &r, GLfloat &g, GLfloat &b) {
+  RunSampleShader(x, y);
+  GetBufferColour(r, g, b);
+}
+
+void TextureSampler::RunSampleShader(float x, float y) {
+  // bind framebuffer
+  fSampleBuffer.Use();
+
+  // enable the shader
+  fSampleShader.use();
+  // bind the texture
+  const GLuint targetUnitNumber = samplerImageUnitNumber;
+  fTarget.Use(targetUnitNumber);
+  // set the uniforms
+  fSampleShader.setInt("target", targetUnitNumber);
+  fSampleShader.set2Vec("sample_coord", x, y);
+  fSampleShader.set2Vec("screen_size", fTarget.GetWidth(), fTarget.GetHeight());
+
+  DrawQuad();
+  // framebuffer should have the correct colour in it
+}
+
+void TextureSampler::GetBufferColour(GLfloat &r, GLfloat &g, GLfloat &b) {
+  // dump the contents of the buffer
+  GLuint texID = GetSamplerTexID();
+  GLfloat imageData[3];
+  glPixelStorei(GL_PACK_ALIGNMENT, 1);
+  glBindTexture(GL_TEXTURE_2D, texID);
+  glGetTexImage(GL_TEXTURE_2D, 0, GL_RGB, GL_FLOAT, imageData);
+  r = imageData[0];
+  g = imageData[1];
+  b = imageData[2];
+}


### PR DESCRIPTION
This creates the `TextureSampler` object, which uses the GPU to sample from one of its loaded textures, as opposed to using the CPU to sample from an image in memory. This ensures that the colours sampled match those in the PNG output, which was not guaranteed previously due to slight differences in image sampling between the GPU and the CPU.

Aims to solve, or at least improve upon, the issue demonstrated in #7.